### PR TITLE
Fix missing package

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ async function execBashCmdAndExportVars(command) {
 }
 
 (async () => {
-  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get install -qq dbus-x11 gnome-keyring");
+  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get install -qq dbus-x11 gnome-keyring --fix-missing");
   await execBashCmdAndExportVars("dbus-launch --sh-syntax");
   await execBashCmdAndExportVars("echo '' | /usr/bin/gnome-keyring-daemon --unlock");
 })().catch(core.setFailed);

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ async function execBashCmdAndExportVars(command) {
 }
 
 (async () => {
-  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get install -qq dbus-x11 gnome-keyring --fix-missing");
+  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get update -qq");
+  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get install -qq dbus-x11 gnome-keyring");
   await execBashCmdAndExportVars("dbus-launch --sh-syntax");
   await execBashCmdAndExportVars("echo '' | /usr/bin/gnome-keyring-daemon --unlock");
 })().catch(core.setFailed);

--- a/index.js
+++ b/index.js
@@ -15,8 +15,13 @@ async function execBashCmdAndExportVars(command) {
 }
 
 (async () => {
-  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get update -qq");
-  await exec.exec((process.getuid() !== 0 ? "sudo " : "") + "apt-get install -qq dbus-x11 gnome-keyring");
+  const aptGet = process.getuid() === 0 ? "apt-get" : "sudo apt-get";
+  try {
+    await exec.exec(`${aptGet} install -qq dbus-x11 gnome-keyring`);
+  } catch (error) {
+    await exec.exec(`${aptGet} update -qq`);
+    await exec.exec(`${aptGet} install -qq dbus-x11 gnome-keyring`);
+  }
   await execBashCmdAndExportVars("dbus-launch --sh-syntax");
   await execBashCmdAndExportVars("echo '' | /usr/bin/gnome-keyring-daemon --unlock");
 })().catch(core.setFailed);

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ async function execBashCmdAndExportVars(command) {
   const aptGet = process.getuid() === 0 ? "apt-get" : "sudo apt-get";
   try {
     await exec.exec(`${aptGet} install -qq dbus-x11 gnome-keyring`);
-  } catch (error) {
+  } catch {
     await exec.exec(`${aptGet} update -qq`);
     await exec.exec(`${aptGet} install -qq dbus-x11 gnome-keyring`);
   }


### PR DESCRIPTION
Normally `apt-get update` is unnecessary because GitHub updates their runner images weekly and the command may have already been run in the workflow.

In some cases, we may need to run `apt-get update` to avoid errors like the following (where the package was updated to `ubuntu2.2` but the cached repository still references `ubuntu2.1`):
```
/usr/bin/sudo apt-get install -qq dbus-x11 gnome-keyring
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/d/dbus/dbus-x11_1.12.16-2ubuntu2.1_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Error: The process '/usr/bin/sudo' failed with exit code 100
```